### PR TITLE
Change mount location and GID to fix permission errors

### DIFF
--- a/files/jupyterhub_config.py
+++ b/files/jupyterhub_config.py
@@ -118,10 +118,12 @@ c.KubeSpawner.volumes = [
 ]
 c.KubeSpawner.volume_mounts = [
   {
-    'mountPath': '/home/jovyan',
+    'mountPath': '/home/jovyan/work',
     'name': 'volume-{username}{servername}'
   }
 ]
+# set the group to "users" ("jovyan" doesn't exist)
+c.KubeSpawner.singleuser_fs_gid = 100
 {%- endif %}
 
 ######## Authenticator ######


### PR DESCRIPTION
The volume was being mounted as `root:root` with no write access for the `jovyan` user,  Overwriting all of `/home/jovyan` also seems excessive (even though that's what the docs suggested), so I also changed it to only mount over the existing `work` folder.