### PR TITLE
Updates from upstream, and use resource for image

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,3 +14,14 @@ options:
     description: |
       Storage class name to use instead of the default storage class
       when creating PVCs per the 'persistent-storage' option.
+  notebook-registry:
+    type: string
+    default: 'gcr.io'
+    description: |
+      Image registry for notebook images.
+  notebook-repo-name:
+    type: string
+    default: 'kubeflow-images-public'
+    description: |
+      Repo name on the registry which contains the TensorFlow Notebook
+      images.

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 options:
-  persistent-storage:
+  notebook-storage-size:
     type: string
     default: ''
     description: |
@@ -8,18 +8,19 @@ options:
       will attach 10 gigabytes of storage to each notebook.  This requires
       a storage class to be defined, and if the 'storage-class' option is
       not set, a storage class to be marked as default.
-  storage-class:
+  notebook-storage-class:
     type: string
     default: ''
     description: |
       Storage class name to use instead of the default storage class
-      when creating PVCs per the 'persistent-storage' option.
-  notebook-registry:
+      when creating PVCs per the 'notebook-storage-size' option.
+      (This option currently doesn't work.  See issue 1).
+  notebook-image-registry:
     type: string
     default: 'gcr.io'
     description: |
       Image registry for notebook images.
-  notebook-repo-name:
+  notebook-image-repo-name:
     type: string
     default: 'kubeflow-images-public'
     description: |

--- a/files/jupyterhub_config.py
+++ b/files/jupyterhub_config.py
@@ -5,22 +5,26 @@ from kubespawner.spawner import KubeSpawner
 from jhub_remote_user_authenticator.remote_user_auth import RemoteUserAuthenticator
 from oauthenticator.github import GitHubOAuthenticator
 
+
 class KubeFormSpawner(KubeSpawner):
 
-  # relies on HTML5 for image datalist
-  def _options_form_default(self):
-    return '''
+    # relies on HTML5 for image datalist
+    def _options_form_default(self):
+        global registry, repoName
+        return '''
     <label for='image'>Image</label>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
     <input list="image" name="image" placeholder='repo/image:tag'>
     <datalist id="image">
-      <option value="gcr.io/kubeflow-images-public/tensorflow-1.4.1-notebook-cpu:v20180419-0ad94c4e">
-      <option value="gcr.io/kubeflow-images-public/tensorflow-1.4.1-notebook-gpu:v20180419-0ad94c4e">
-      <option value="gcr.io/kubeflow-images-public/tensorflow-1.5.1-notebook-cpu:v20180419-0ad94c4e">
-      <option value="gcr.io/kubeflow-images-public/tensorflow-1.5.1-notebook-gpu:v20180419-0ad94c4e">
-      <option value="gcr.io/kubeflow-images-public/tensorflow-1.6.0-notebook-cpu:v20180419-0ad94c4e">
-      <option value="gcr.io/kubeflow-images-public/tensorflow-1.6.0-notebook-gpu:v20180419-0ad94c4e">
-      <option value="gcr.io/kubeflow-images-public/tensorflow-1.7.0-notebook-cpu:v20180419-0ad94c4e">
-      <option value="gcr.io/kubeflow-images-public/tensorflow-1.7.0-notebook-gpu:v20180419-0ad94c4e">
+      <option value="{0}/{1}/tensorflow-1.4.1-notebook-cpu:v0.2.1">
+      <option value="{0}/{1}/tensorflow-1.4.1-notebook-gpu:v0.2.1">
+      <option value="{0}/{1}/tensorflow-1.5.1-notebook-cpu:v0.2.1">
+      <option value="{0}/{1}/tensorflow-1.5.1-notebook-gpu:v0.2.1">
+      <option value="{0}/{1}/tensorflow-1.6.0-notebook-cpu:v0.2.1">
+      <option value="{0}/{1}/tensorflow-1.6.0-notebook-gpu:v0.2.1">
+      <option value="{0}/{1}/tensorflow-1.7.0-notebook-cpu:v0.2.1">
+      <option value="{0}/{1}/tensorflow-1.7.0-notebook-gpu:v0.2.1">
+      <option value="{0}/{1}/tensorflow-1.8.0-notebook-cpu:v0.2.1">
+      <option value="{0}/{1}/tensorflow-1.8.0-notebook-gpu:v0.2.1">
     </datalist>
     <br/><br/>
 
@@ -33,48 +37,56 @@ class KubeFormSpawner(KubeSpawner):
     <br/><br/>
 
     <label for='extra_resource_limits'>Extra Resource Limits</label>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-    <input name='extra_resource_limits' placeholder='{&apos;nvidia.com/gpu&apos;: &apos;3&apos;}'></input>
+    <input name='extra_resource_limits' placeholder='{{&quot;nvidia.com/gpu&quot;: 3}}'></input>
     <br/><br/>
-    '''
+    '''.format(registry, repoName)
 
-  def options_from_form(self, formdata):
-    options = {}
-    options['image'] = formdata.get('image', [''])[0].strip()
-    options['cpu_guarantee'] = formdata.get('cpu_guarantee', [''])[0].strip()
-    options['mem_guarantee'] = formdata.get('mem_guarantee', [''])[0].strip()
-    options['extra_resource_limits'] = formdata.get('extra_resource_limits', [''])[0].strip()
-    return options
+    def options_from_form(self, formdata):
+        options = {}
+        options['image'] = formdata.get('image', [''])[0].strip()
+        options['cpu_guarantee'] = formdata.get(
+            'cpu_guarantee', [''])[0].strip()
+        options['mem_guarantee'] = formdata.get(
+            'mem_guarantee', [''])[0].strip()
+        options['extra_resource_limits'] = formdata.get(
+            'extra_resource_limits', [''])[0].strip()
+        return options
 
-  @property
-  def singleuser_image_spec(self):
-    image = 'gcr.io/kubeflow/tensorflow-notebook-cpu'
-    if self.user_options.get('image'):
-      image = self.user_options['image']
-    return image
+    @property
+    def singleuser_image_spec(self):
+        global cloud
+        if cloud == 'ack':
+            image = 'registry.aliyuncs.com/kubeflow-images-public/tensorflow-notebook-cpu'
+        else:
+            image = 'gcr.io/kubeflow-images-public/tensorflow-1.8.0-notebook-cpu:v0.2.1'
+        if self.user_options.get('image'):
+            image = self.user_options['image']
+        return image
 
-  @property
-  def cpu_guarantee(self):
-    cpu = '500m'
-    if self.user_options.get('cpu_guarantee'):
-      cpu = self.user_options['cpu_guarantee']
-    return cpu
+    @property
+    def cpu_guarantee(self):
+        cpu = '500m'
+        if self.user_options.get('cpu_guarantee'):
+            cpu = self.user_options['cpu_guarantee']
+        return cpu
 
-  @property
-  def mem_guarantee(self):
-    mem = '1Gi'
-    if self.user_options.get('mem_guarantee'):
-      mem = self.user_options['mem_guarantee']
-    return mem
+    @property
+    def mem_guarantee(self):
+        mem = '1Gi'
+        if self.user_options.get('mem_guarantee'):
+            mem = self.user_options['mem_guarantee']
+        return mem
 
-  @property
-  def extra_resource_limits(self):
-    extra = ''
-    if self.user_options.get('extra_resource_limits'):
-      extra = json.loads(self.user_options['extra_resource_limits'])
-    return extra
+    @property
+    def extra_resource_limits(self):
+        extra = ''
+        if self.user_options.get('extra_resource_limits'):
+            extra = json.loads(self.user_options['extra_resource_limits'])
+        return extra
+
 
 ###################################################
-### JupyterHub Options
+# JupyterHub Options
 ###################################################
 c.JupyterHub.ip = '0.0.0.0'
 c.JupyterHub.hub_ip = '0.0.0.0'
@@ -84,19 +96,32 @@ c.JupyterHub.cleanup_servers = False
 ###################################################
 
 ###################################################
-### Spawner Options
+# Spawner Options
 ###################################################
+cloud = os.environ.get('CLOUD_NAME')
+registry = os.environ.get('REGISTRY')
+repoName = os.environ.get('REPO_NAME')
 c.JupyterHub.spawner_class = KubeFormSpawner
-c.KubeSpawner.singleuser_image_spec = 'gcr.io/kubeflow/tensorflow-notebook'
+c.KubeSpawner.singleuser_image_spec = '{0}/{1}/tensorflow-notebook'.format(registry, repoName)
+
 c.KubeSpawner.cmd = 'start-singleuser.sh'
 c.KubeSpawner.args = ['--allow-root']
 # gpu images are very large ~15GB. need a large timeout.
 c.KubeSpawner.start_timeout = 60 * 30
 # Increase timeout to 5 minutes to avoid HTTP 500 errors on JupyterHub
 c.KubeSpawner.http_timeout = 60 * 5
+
+# Volume setup
+c.KubeSpawner.singleuser_uid = 1000
+c.KubeSpawner.singleuser_fs_gid = 100
+c.KubeSpawner.singleuser_working_dir = '/home/jovyan'
+
 # override API hostname since it doesn't match the pod name
 c.KubeSpawner.hub_connect_ip = '{{k8s_service_name}}'  # not actually honored :(
 c.KubeSpawner.args.append('--hub-api-url=http://{{k8s_service_name}}:8081/hub/api')
+
+volumes = []
+volume_mounts = []
 
 {% if config['persistent-storage'] -%}
 ###################################################
@@ -108,23 +133,42 @@ c.KubeSpawner.user_storage_capacity = '{{config['persistent-storage']}}'
 c.KubeSpawner.storage_class = '{{config['storage-class']}}'
 {%- endif %}
 c.KubeSpawner.pvc_name_template = 'claim-{username}{servername}'
-c.KubeSpawner.volumes = [
-  {
-    'name': 'volume-{username}{servername}',
-    'persistentVolumeClaim': {
-      'claimName': 'claim-{username}{servername}'
+volumes.append(
+    {
+        'name': 'volume-{username}{servername}',
+        'persistentVolumeClaim': {
+            'claimName': 'claim-{username}{servername}'
+        }
     }
-  }
-]
-c.KubeSpawner.volume_mounts = [
+)
+volume_mounts.append(
   {
-    'mountPath': '/home/jovyan/work',
+    'mountPath': '/home/jovyan',
     'name': 'volume-{username}{servername}'
   }
-]
-# set the group to "users" ("jovyan" doesn't exist)
-c.KubeSpawner.singleuser_fs_gid = 100
+)
 {%- endif %}
+
+# ###################################################
+# ### Extra volumes for NVIDIA drivers (Azure)
+# ###################################################
+# # Temporary fix:
+# # AKS / acs-engine doesn't yet use device plugin so we have to mount the drivers to use GPU
+# # TODO(wbuchwalter): Remove once device plugin is merged
+if cloud == 'aks' or cloud == 'acsengine':
+    volumes.append({
+        'name': 'nvidia',
+        'hostPath': {
+            'path': '/usr/local/nvidia'
+        }
+    })
+    volume_mounts.append({
+        'name': 'nvidia',
+        'mountPath': '/usr/local/nvidia'
+    })
+
+c.KubeSpawner.volumes = volumes
+c.KubeSpawner.volume_mounts = volume_mounts
 
 ######## Authenticator ######
 c.JupyterHub.authenticator_class = 'dummyauthenticator.DummyAuthenticator'

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,3 +17,7 @@ tags:
   - kubeflow
 series:
   - kubernetes
+resources:
+  jupyterhub-image:
+    type: docker
+    description: 'Image used for JupyterHub'

--- a/reactive/kubeflow_tf_hub.py
+++ b/reactive/kubeflow_tf_hub.py
@@ -16,12 +16,14 @@ def get_image():
     layer.status.maintenance('fetching container image')
     try:
         image_info_filename = hookenv.resource_get('jupyterhub-image')
-        if image_info_filename:
-            raise ValueError()
+        if not image_info_filename:
+            raise ValueError('no filename returned for resource')
         image_info = yaml.safe_load(Path(image_info_filename).read_text())
         if not image_info:
-            raise ValueError()
-    except Exception:
+            raise ValueError('no data returned for resource')
+    except Exception as e:
+        hookenv.log('unable to fetch container image: {}'.format(e),
+                    level=hookenv.ERROR)
         layer.status.blocked('unable to fetch container image')
     else:
         unitdata.kv().set('charm.kubeflow-tf-hub.image-info', image_info)


### PR DESCRIPTION
There was a new upstream release for 0.2.1, including new images.

This also switches to using Juju resources for the JupyterHub image. We may also want to switch to resources for the TensorFlow images but they are quite large and maybe not ideal for going through the staging server.  Also, since the form displays the entire image path, including the repo, it may seem like we're deviating more from upstream, though we could certainly change how they're presented in the form.